### PR TITLE
Remove argparse from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
     },
     python_requires=">=3.6, <4",
     install_requires=[
-        "argparse >= 1.4.0",
         "netaddr >= 0.7.19",
         "scapy >= 2.4.3",
     ],


### PR DESCRIPTION
`argparse` is a [standard module](https://docs.python.org/3/library/argparse.html) and not need as `>=3.6` is set.

